### PR TITLE
Rais 3 routing

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -18,7 +18,7 @@ model and the name of the User model.
 
 For all examples in the readme, we will use Message and User.
 
-  rails generate simple_private_messages:model Message User
+  rails generate simple_private_messages:model User Message
 
 Now add the following entry to the model which will have the messages
 
@@ -107,7 +107,7 @@ A generator is included to create a basic controller and set of views.
 
 Run the simple_private_messages:scaffold generator with the same options as before:
 
-  rails generate simple_private_messages:scaffold Message User
+  rails generate simple_private_messages:scaffold User Message
 
 The controller will be named with the pluralised version of the model name.
 

--- a/lib/generators/simple_private_messages/scaffold/scaffold_generator.rb
+++ b/lib/generators/simple_private_messages/scaffold/scaffold_generator.rb
@@ -26,9 +26,13 @@ class ScaffoldGenerator < Rails::Generators::Base
     @singular_lower_case_parent = user_model_name.singularize.underscore
     @plural_lower_case_parent = user_model_name.pluralize.underscore    
   
-  		route("resources :#{@plural_lower_case_parent} do 
-		    resources :#{@plural_lower_case_name}, :collection => { :delete_selected => :post }
-		end")
+  	route("resources :#{@plural_lower_case_parent} do 
+		    resources :#{@plural_lower_case_name} do
+          collection do
+            post :delete_selected
+          end
+        end
+		  end")
   
       #directory "app/controllers"
       template "controller.rb", "app/controllers/#{@plural_lower_case_name}_controller.rb"

--- a/lib/generators/simple_private_messages/scaffold/templates/view_index.html.erb
+++ b/lib/generators/simple_private_messages/scaffold/templates/view_index.html.erb
@@ -1,4 +1,4 @@
-<%% form_tag delete_selected_user_<%= plural_lower_case_name %>_path(@<%= singular_lower_case_parent %>) do %>
+<%% form_tag delete_selected_user_<%= plural_lower_case_name %>_path(@<%= singular_lower_case_parent %>, :method => :post) do %>
 	<%% if params[:mailbox] == "sent" %>
 			<%%= render :partial => "sent" %>
 	<%% else %>


### PR DESCRIPTION
Hiya, I've added actual rails 3 routing for the delete_selected route.
Rails 3 routing is meant to be backwards compatible, but I couldn't get it to see that route at all.
So I've updated it to the new rails 3 syntax.
However - it won't work with rails 2.X So probably there should be a check for rails_version before using this syntax.
Just thought you might wanna have a look :)
Cheers,
Taryn
