### PR TITLE
deleting messages & migration for heroku

### DIFF
--- a/lib/generators/simple_private_messages/model/templates/migration.rb
+++ b/lib/generators/simple_private_messages/model/templates/migration.rb
@@ -2,7 +2,7 @@ class <%= "Create#{plural_camel_case_name}" %> < ActiveRecord::Migration
   def self.up
     create_table :<%= plural_lower_case_name %> do |t|
       t.integer :sender_id, :recipient_id
-      t.boolean :sender_deleted, :recipient_deleted, :default => 0
+      t.boolean :sender_deleted, :recipient_deleted, :default => false
       t.string :subject
       t.text :body
       t.datetime :read_at

--- a/lib/generators/simple_private_messages/scaffold/templates/controller.rb
+++ b/lib/generators/simple_private_messages/scaffold/templates/controller.rb
@@ -49,7 +49,7 @@ class <%= plural_camel_case_name %>Controller < ApplicationController
         }
         flash[:notice] = "Messages deleted"
       end
-      redirect_to user_<%= singular_lower_case_name %>_path(@<%= singular_lower_case_parent %>, @<%= plural_lower_case_name %>)
+      redirect_to :back
     end
   end
   


### PR DESCRIPTION
redirect back after deleting messages makes more sense, and migration needed to be fixed for heroku.
