### PR TITLE
Don't show deleted messages in unread message count

### DIFF
--- a/lib/has_private_messages_extensions.rb
+++ b/lib/has_private_messages_extensions.rb
@@ -48,7 +48,7 @@ module Professionalnerd #:nodoc:
         
         # Returns the number of unread messages for this user
         def unread_message_count
-          eval options[:class_name] + '.count(:conditions => ["recipient_id = ? AND read_at IS NULL", self])'
+          eval options[:class_name] + '.count(:conditions => ["recipient_id = ? AND read_at IS NULL and recipient_deleted = ?", self, false])'
         end
       end 
     end


### PR DESCRIPTION
unread_message_count sometimes returns the incorrect value if users have deleted messages without reading them. So you can have received_messages returning no messages but unread_message_count giving a value greater than 0.
