### PR TITLE
Bugfix for failing migration with postgresql

### DIFF
--- a/lib/generators/simple_private_messages/model/templates/migration.rb
+++ b/lib/generators/simple_private_messages/model/templates/migration.rb
@@ -2,7 +2,7 @@ class <%= "Create#{plural_camel_case_name}" %> < ActiveRecord::Migration
   def self.up
     create_table :<%= plural_lower_case_name %> do |t|
       t.integer :sender_id, :recipient_id
-      t.boolean :sender_deleted, :recipient_deleted, :default => 0
+      t.boolean :sender_deleted, :recipient_deleted, :default => false
       t.string :subject
       t.text :body
       t.datetime :read_at


### PR DESCRIPTION
Postgresql didn't like it when the default values for :sender_deleted and :recipient_deleted are integers while the data type is a boolean. So I gave it false instead of 0.
